### PR TITLE
Keep target center within bounds

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,10 +124,12 @@ let runState = new RunState();
 // Helper Functions
 
 // Random target placement
-function randomTarget(side) {
-    return { 
-        x: Math.random() * side, 
-        y: Math.random() * side 
+function randomTarget(side, radius) {
+    const min = radius;
+    const max = side - radius;
+    return {
+        x: min + Math.random() * (max - min),
+        y: min + Math.random() * (max - min)
     };
 }
 
@@ -207,19 +209,19 @@ function removeTarget(gameArea) {
 }
 
 function updateTargetPosition(gameArea) {
-    const containerSize = gameArea.offsetWidth;
-    runState.target = randomTarget(containerSize);
+    const containerSize = gameArea.clientWidth;
+    runState.target = randomTarget(containerSize, runState.currentR);
     renderTarget(gameArea, runState.target.x, runState.target.y, runState.currentR);
 }
 
 // State Transition Functions
 
 function transitionToPlaying(gameArea) {
-    const containerSize = gameArea.offsetWidth; // Square, so width = height
+    const containerSize = gameArea.clientWidth; // Square, so width = height
     runState.startGame(containerSize);
-    
+
     // Place first target
-    runState.target = randomTarget(containerSize);
+    runState.target = randomTarget(containerSize, runState.currentR);
     renderTarget(gameArea, runState.target.x, runState.target.y, runState.currentR);
 }
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
             <div class="space-y-3 mb-6">
                 <p class="text-gray-600">Click inside the circle. After each hit, the circle shrinks and moves.</p>
                 <p class="text-gray-600 font-semibold">One miss ends the run.</p>
-                <p class="text-sm text-gray-500 italic">Note: Partial off-edge placement is intentional.</p>
+                <p class="text-sm text-gray-500 italic">The target's center always stays within the square.</p>
             </div>
             <button id="start-btn" class="w-full bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-lg transition-colors">
                 Start


### PR DESCRIPTION
## Summary
- Constrain random target positions to remain inside the game square
- Use clientWidth and pass radius when repositioning targets
- Clarify instructions that the target's center always stays within the square

## Testing
- `node --check app.js && echo "syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f3a6d23c832da006927996ad9b9f