### PR TITLE
Improve mobile game-over modal layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -218,20 +218,20 @@
             
             
             <!-- Action Buttons -->
-            <div class="flex justify-center space-x-3">
-                <button id="restart-modal-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-6 rounded-lg transition-colors">
-                    Play Again
-                </button>
-                <a href="/leaderboard.html" class="bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-2 px-6 rounded-lg transition-colors inline-flex items-center">
-                    <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
-                    </svg>
-                    Leaderboard
-                </a>
-                <button id="share-btn" class="bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-6 rounded-lg transition-colors">
-                    Share Screenshot
-                </button>
-            </div>
+              <div class="flex flex-col items-center space-y-3 sm:flex-row sm:space-y-0 sm:space-x-3">
+                  <button id="restart-modal-btn" class="w-full sm:w-auto bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-6 rounded-lg transition-colors">
+                      Play Again
+                  </button>
+                  <a href="/leaderboard.html" class="w-full sm:w-auto bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-2 px-6 rounded-lg transition-colors inline-flex items-center justify-center">
+                      <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+                      </svg>
+                      Leaderboard
+                  </a>
+                  <button id="share-btn" class="w-full sm:w-auto bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-6 rounded-lg transition-colors">
+                      Share Screenshot
+                  </button>
+              </div>
         </div>
     </div>
     

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -248,26 +248,26 @@ function updateMainStatistics(modal, performanceScore, speedScore, scoring, runS
                     <div class="text-xs text-blue-500">Timing & Efficiency</div>
                 </div>
             </div>
-            <div class="grid grid-cols-5 gap-1">
+            <div class="grid grid-cols-2 sm:grid-cols-5 gap-1">
                 <div class="bg-white p-1.5 rounded shadow-sm text-center">
                     <div class="text-xs text-gray-500">Total Hits</div>
-                    <div class="text-sm font-semibold text-gray-700">${runState.hits}</div>
+                    <div class="text-xs sm:text-sm font-semibold text-gray-700">${runState.hits}</div>
                 </div>
                 <div class="bg-white p-1.5 rounded shadow-sm text-center">
                     <div class="text-xs text-gray-500">Avg Accuracy</div>
-                    <div class="text-sm font-semibold text-gray-700">${formatPercentage(runState.getAverageAccuracy())}</div>
+                    <div class="text-xs sm:text-sm font-semibold text-gray-700">${formatPercentage(runState.getAverageAccuracy())}</div>
                 </div>
                 <div class="bg-white p-1.5 rounded shadow-sm text-center">
                     <div class="text-xs text-gray-500">Best Accuracy</div>
-                    <div class="text-sm font-semibold text-gray-700">${formatPercentage(runState.bestAccuracy)}</div>
+                    <div class="text-xs sm:text-sm font-semibold text-gray-700">${formatPercentage(runState.bestAccuracy)}</div>
                 </div>
                 <div class="bg-white p-1.5 rounded shadow-sm text-center">
                     <div class="text-xs text-gray-500">Final Size</div>
-                    <div class="text-sm font-semibold text-gray-700">${runState.finalRadius}px</div>
+                    <div class="text-xs sm:text-sm font-semibold text-gray-700">${runState.finalRadius}px</div>
                 </div>
                 <div class="bg-white p-1.5 rounded shadow-sm text-center">
                     <div class="text-xs text-gray-500">Duration</div>
-                    <div class="text-sm font-semibold text-gray-700">${formatTime(runState.getDuration())}</div>
+                    <div class="text-xs sm:text-sm font-semibold text-gray-700">${formatTime(runState.getDuration())}</div>
                 </div>
             </div>
         </div>
@@ -302,18 +302,18 @@ function addUsernameSection(modal) {
     // Update username section content
     usernameSection.innerHTML = `
         <div class="bg-gray-50 p-2 rounded border border-gray-200">
-            <div class="flex items-center space-x-2">
-                <label class="text-sm font-medium text-gray-700 whitespace-nowrap">Anon, save your name to get on the leaderboard:</label>
-                <input 
-                    type="text" 
+            <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-2 space-y-2 sm:space-y-0">
+                <label class="text-xs sm:text-sm font-medium text-gray-700">Anon, save your name to get on the leaderboard:</label>
+                <input
+                    type="text"
                     id="username-input"
-                    placeholder="Enter your name..." 
+                    placeholder="Enter your name..."
                     maxlength="20"
-                    class="flex-1 px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                    class="flex-1 px-2 py-1 border border-gray-300 rounded text-sm w-full sm:w-auto focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent"
                 />
-                <button 
+                <button
                     id="save-username-btn"
-                    class="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded transition-colors whitespace-nowrap"
+                    class="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded transition-colors w-full sm:w-auto"
                 >
                     Save
                 </button>
@@ -509,7 +509,7 @@ async function createScatterPlotVisualization(modal, speedScore, performanceScor
         <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
             <h3 class="text-base font-bold text-gray-800 mb-2 text-center">Performance vs. All Players</h3>
             <div class="flex justify-center">
-                <svg id="modal-scatter-plot" width="600" height="250" class="bg-white border border-gray-300 rounded-lg">
+                <svg id="modal-scatter-plot" class="bg-white border border-gray-300 rounded-lg w-full max-w-[600px]" viewBox="0 0 600 250">
                     <!-- Chart content will be rendered here -->
                 </svg>
             </div>
@@ -589,13 +589,17 @@ function renderModalScatterPlot(data) {
     
     // Chart configuration
     const config = {
-        width: 600,
+        width: Math.min(600, window.innerWidth - 80),
         height: 250,
         margin: { top: 15, right: 20, bottom: 55, left: 65 },
         maxSpeed: 100,
         maxPerformance: 100
     };
-    
+
+    svg.setAttribute('width', String(config.width));
+    svg.setAttribute('height', String(config.height));
+    svg.setAttribute('viewBox', `0 0 ${config.width} ${config.height}`);
+
     const chartWidth = config.width - config.margin.left - config.margin.right;
     const chartHeight = config.height - config.margin.top - config.margin.bottom;
     


### PR DESCRIPTION
## Summary
- Stack action buttons vertically on mobile for the game-over modal
- Make final stats and username input responsive and wrap nicely
- Render scatter plot at a responsive width to avoid horizontal overflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c7567238832daff1676913938186