### PR TITLE
feat: show remaining clicks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,7 @@
     
     <!-- Main Game Container -->
     <main class="flex flex-col items-center">
+        <div id="clicks-left" class="mb-4 text-lg font-semibold text-gray-700">20 clicks left</div>
         <!-- Game Area (Square) -->
         <div id="game-area" class="game-container relative bg-white border-2 border-gray-300 rounded-lg shadow-lg">
             <!-- Target circle will be rendered here dynamically -->

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const startBtn = document.getElementById('start-btn');
     const restartBtn = document.getElementById('restart-btn');
     const gameArea = document.getElementById('game-area');
+    const clicksLeft = document.getElementById('clicks-left');
     const liveStats = document.getElementById('live-stats');
     const scorecard = document.getElementById('scorecard');
     
@@ -43,7 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
         statAvgAccuracy: document.getElementById('stat-avg-accuracy'),
         statBestAccuracy: document.getElementById('stat-best-accuracy'),
         statCurrentSize: document.getElementById('stat-current-size'),
-        statElapsedTime: document.getElementById('stat-elapsed-time')
+        statElapsedTime: document.getElementById('stat-elapsed-time'),
+        clicksLeft
     };
     
     // Get scorecard elements (legacy)
@@ -78,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Create event handlers
     const handleGameClick = createClickHandler(gameArea, runState, statElements, timerRef, gameOverElements);
     const handleStart = createStartHandler(gameArea, runState, modal, liveStats, statElements, timerRef);
-    const handleRestart = createRestartHandler(gameArea, runState, modal, gameOverModal, scorecard, liveStats, timerRef);
+    const handleRestart = createRestartHandler(gameArea, runState, modal, gameOverModal, scorecard, liveStats, timerRef, statElements);
     
     // Add click listener to game area
     gameArea.addEventListener('click', handleGameClick);

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -197,7 +197,7 @@ export function createStartHandler(gameArea, runState, modal, liveStats, statEle
     };
 }
 
-export function createRestartHandler(gameArea, runState, modal, gameOverModal, scorecard, liveStats, timerRef) {
+export function createRestartHandler(gameArea, runState, modal, gameOverModal, scorecard, liveStats, timerRef, statElements) {
     return function handleRestart() {
         // Reset state
         transitionToIdle(runState);
@@ -212,6 +212,11 @@ export function createRestartHandler(gameArea, runState, modal, gameOverModal, s
         gameOverModal.classList.add('hidden');
         scorecard.classList.add('hidden');
         liveStats.classList.add('hidden');
+
+        // Reset clicks left display
+        if (statElements?.clicksLeft) {
+            statElements.clicksLeft.textContent = `${CONFIG.SHRINK_STEPS_APPROX} clicks left`;
+        }
         
         // Show start modal
         modal.style.display = 'flex';

--- a/public/js/renderer.js
+++ b/public/js/renderer.js
@@ -1,6 +1,7 @@
 // Click Accuracy Game - Rendering and UI
 
 import { formatPercentage, formatTime, randomTarget } from './game-logic.js';
+import { CONFIG } from './config.js';
 
 // Target Rendering Functions
 
@@ -45,22 +46,28 @@ export function updateTargetPosition(gameArea, runState) {
 
 export function updateLiveStats(runState, statElements) {
     if (runState.phase !== 'playing') return;
-    
-    const { statHits, statAvgAccuracy, statBestAccuracy, statCurrentSize, statElapsedTime } = statElements;
-    
+
+    const { statHits, statAvgAccuracy, statBestAccuracy, statCurrentSize, statElapsedTime, clicksLeft } = statElements;
+
     // Update hit count
     statHits.textContent = runState.hits;
-    
+
+    // Update remaining clicks display
+    if (clicksLeft) {
+        const remaining = Math.max(0, CONFIG.SHRINK_STEPS_APPROX - runState.hits);
+        clicksLeft.textContent = `${remaining} clicks left`;
+    }
+
     // Update average accuracy
     const avgAccuracy = runState.getAverageAccuracy();
     statAvgAccuracy.textContent = formatPercentage(avgAccuracy);
-    
+
     // Update best accuracy
     statBestAccuracy.textContent = formatPercentage(runState.bestAccuracy);
-    
+
     // Update current size
     statCurrentSize.textContent = runState.currentR + 'px';
-    
+
     // Update elapsed time
     const elapsed = runState.getDuration();
     statElapsedTime.textContent = formatTime(elapsed);


### PR DESCRIPTION
## Summary
- show remaining clicks above game area
- update display after each hit and when restarting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05d3eecc832d93d50f11617c0afd