### PR TITLE
Make leaderboard scatter plot responsive

### DIFF
--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -252,7 +252,7 @@ function renderScatterPlot(scatterData) {
     if (!svg || !scatterData) return;
     
     svg.innerHTML = ''; // Clear previous content
-    
+
     // Chart configuration
     const config = {
         width: 700,
@@ -261,6 +261,10 @@ function renderScatterPlot(scatterData) {
         maxSpeed: 100,
         maxPerformance: 100
     };
+
+    // Make the SVG responsive by scaling to its container
+    svg.setAttribute('viewBox', `0 0 ${config.width} ${config.height}`);
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
     
     const chartWidth = config.width - config.margin.left - config.margin.right;
     const chartHeight = config.height - config.margin.top - config.margin.bottom;

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -97,7 +97,7 @@
                 </div>
                 <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
                     <div class="flex justify-center">
-                        <svg id="leaderboard-scatter-plot" width="700" height="300" class="bg-white border border-gray-300 rounded-lg">
+                        <svg id="leaderboard-scatter-plot" viewBox="0 0 700 300" class="w-full h-auto bg-white border border-gray-300 rounded-lg">
                             <!-- Scatter plot will be rendered here -->
                         </svg>
                     </div>


### PR DESCRIPTION
## Summary
- ensure leaderboard scatter plot scales within mobile viewport
- add viewBox and preserveAspectRatio so the chart resizes with container

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb0f3e000832db979038e884306ac