### PR TITLE
Improve mobile header responsiveness on leaderboard

### DIFF
--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -44,13 +44,13 @@
     <!-- Header -->
     <header class="bg-white shadow-sm border-b border-gray-200">
         <div class="max-w-6xl mx-auto px-4 py-4">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-4">
-                    <h1 class="text-2xl font-bold text-gray-800">ClickAccuracy.com</h1>
-                    <span class="text-gray-400">|</span>
-                    <h2 class="text-xl font-semibold text-blue-600">Leaderboard</h2>
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+                <div class="flex items-center justify-center sm:justify-start space-x-2 text-sm sm:text-base">
+                    <h1 class="text-lg sm:text-2xl font-bold text-gray-800">ClickAccuracy.com</h1>
+                    <span class="text-gray-400 hidden sm:inline">|</span>
+                    <h2 class="text-base sm:text-xl font-semibold text-blue-600">Leaderboard</h2>
                 </div>
-                <nav class="flex space-x-4">
+                <nav class="mt-4 sm:mt-0 flex justify-center sm:justify-end">
                     <a href="/" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors">
                         Play Game
                     </a>


### PR DESCRIPTION
## Summary
- make leaderboard header responsive on small screens
- reduce site title size and center Play Game button on mobile

## Testing
- `npm install` *(fails: 403 Forbidden fetching @testing-library/dom)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb85856d4832d8be7267ab3c58760